### PR TITLE
お知らせ詳細画面追加

### DIFF
--- a/Jinkawa-iOS.xcodeproj/project.pbxproj
+++ b/Jinkawa-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		19DCFB891F9CC255006F2D58 /* InformationDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DCFB881F9CC255006F2D58 /* InformationDetailViewController.swift */; };
 		375810CF1F9B3BEC0095B29C /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375810CE1F9B3BEC0095B29C /* SettingViewController.swift */; };
 		5534EFB71F84B30D00C85E5B /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5534EFB61F84B30D00C85E5B /* UserManager.swift */; };
 		556A29CC1EFCD8B500FC82E1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556A29CB1EFCD8B500FC82E1 /* AppDelegate.swift */; };
@@ -60,6 +61,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		19DCFB881F9CC255006F2D58 /* InformationDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationDetailViewController.swift; sourceTree = "<group>"; };
 		375810CE1F9B3BEC0095B29C /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		5534EFB61F84B30D00C85E5B /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		556A29C81EFCD8B500FC82E1 /* Jinkawa-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Jinkawa-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -200,6 +202,7 @@
 				55F8EE6D1F696EB600D9E64E /* EventDetailViewController.swift */,
 				55DF2DD31F6CC808002491E1 /* EventCreateViewController.swift */,
 				55C99F991F126E6D0089851A /* InformationViewController.swift */,
+				19DCFB881F9CC255006F2D58 /* InformationDetailViewController.swift */,
 				55E07F841F6D4EBA0056E726 /* InformationCreateViewController.swift */,
 				55C3E34B1F6BE9CB0026E9EE /* PartisipantViewController.swift */,
 				55F8EE6F1F69719800D9E64E /* EntryViewController.swift */,
@@ -415,6 +418,7 @@
 				55F8EE701F69719800D9E64E /* EntryViewController.swift in Sources */,
 				55F8EE6E1F696EB600D9E64E /* EventDetailViewController.swift in Sources */,
 				55C99F981F1269570089851A /* InformationManager.swift in Sources */,
+				19DCFB891F9CC255006F2D58 /* InformationDetailViewController.swift in Sources */,
 				559FC0961F6A67DD00FB5ABE /* ParticipantManager.swift in Sources */,
 				55C99F831F11BDA40089851A /* EventItemViewCell.swift in Sources */,
 				55C99F951F12692A0089851A /* InformationItemViewCell.swift in Sources */,

--- a/Jinkawa-iOS/Base.lproj/Main.storyboard
+++ b/Jinkawa-iOS/Base.lproj/Main.storyboard
@@ -174,11 +174,56 @@
                     <connections>
                         <outlet property="informationListView" destination="fx8-Kc-9yy" id="mPH-1a-xDU"/>
                         <segue destination="5DY-SI-qys" kind="show" identifier="toInformationCreate" id="Aw6-7i-04g"/>
+                        <segue destination="Yv5-qq-obu" kind="show" identifier="toInformationDetail" id="VYa-e8-uzm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RMl-N9-KWX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3305" y="143"/>
+        </scene>
+        <!--お知らせ詳細-->
+        <scene sceneID="T42-qe-pnA">
+            <objects>
+                <viewController id="Yv5-qq-obu" customClass="InformationDetailViewController" customModule="Jinkawa_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="gzs-9R-2Tc"/>
+                        <viewControllerLayoutGuide type="bottom" id="8dJ-1u-9W2"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="qlx-Ow-gaJ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="9IB-bd-px7">
+                                <rect key="frame" x="0.0" y="322" width="375" height="296"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            </tableView>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kSu-ZE-rpa">
+                                <rect key="frame" x="0.0" y="64" width="375" height="250"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="250" id="sTw-JU-wgs"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="9IB-bd-px7" firstAttribute="top" secondItem="kSu-ZE-rpa" secondAttribute="bottom" constant="8" id="3Lw-Gw-aBG"/>
+                            <constraint firstItem="9IB-bd-px7" firstAttribute="top" secondItem="kSu-ZE-rpa" secondAttribute="bottom" constant="8" id="TUa-R1-7ZC"/>
+                            <constraint firstItem="8dJ-1u-9W2" firstAttribute="top" secondItem="9IB-bd-px7" secondAttribute="bottom" id="XGk-Sa-1GQ"/>
+                            <constraint firstAttribute="trailing" secondItem="9IB-bd-px7" secondAttribute="trailing" id="Ye0-Rv-UId"/>
+                            <constraint firstItem="9IB-bd-px7" firstAttribute="leading" secondItem="qlx-Ow-gaJ" secondAttribute="leading" id="g9J-EF-uzE"/>
+                            <constraint firstAttribute="trailing" secondItem="kSu-ZE-rpa" secondAttribute="trailing" id="hda-fC-HUJ"/>
+                            <constraint firstItem="kSu-ZE-rpa" firstAttribute="leading" secondItem="qlx-Ow-gaJ" secondAttribute="leading" id="lTL-rr-4q0"/>
+                            <constraint firstItem="kSu-ZE-rpa" firstAttribute="top" secondItem="gzs-9R-2Tc" secondAttribute="bottom" id="yku-bM-wqM"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="お知らせ詳細" id="KCx-MV-b6h"/>
+                    <connections>
+                        <outlet property="detailTable" destination="9IB-bd-px7" id="Zj6-c3-YbS"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uHn-b7-ymB" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4120.8000000000002" y="142.1289355322339"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="qFQ-bR-Jwj">
@@ -220,7 +265,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lXp-eW-Vuy" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4121" y="142"/>
+            <point key="canvasLocation" x="4121" y="983"/>
         </scene>
         <!--設定-->
         <scene sceneID="aaG-Ix-hiT">

--- a/Jinkawa-iOS/Base.lproj/Main.storyboard
+++ b/Jinkawa-iOS/Base.lproj/Main.storyboard
@@ -193,16 +193,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="9IB-bd-px7">
-                                <rect key="frame" x="0.0" y="322" width="375" height="296"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            </tableView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kSu-ZE-rpa">
                                 <rect key="frame" x="0.0" y="64" width="375" height="250"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="250" id="sTw-JU-wgs"/>
                                 </constraints>
                             </imageView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="9IB-bd-px7">
+                                <rect key="frame" x="0.0" y="322" width="375" height="296"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -213,7 +213,7 @@
                             <constraint firstItem="9IB-bd-px7" firstAttribute="leading" secondItem="qlx-Ow-gaJ" secondAttribute="leading" id="g9J-EF-uzE"/>
                             <constraint firstAttribute="trailing" secondItem="kSu-ZE-rpa" secondAttribute="trailing" id="hda-fC-HUJ"/>
                             <constraint firstItem="kSu-ZE-rpa" firstAttribute="leading" secondItem="qlx-Ow-gaJ" secondAttribute="leading" id="lTL-rr-4q0"/>
-                            <constraint firstItem="kSu-ZE-rpa" firstAttribute="top" secondItem="gzs-9R-2Tc" secondAttribute="bottom" id="yku-bM-wqM"/>
+                            <constraint firstItem="kSu-ZE-rpa" firstAttribute="top" secondItem="gzs-9R-2Tc" secondAttribute="bottom" id="mOW-bj-20s"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="お知らせ詳細" id="KCx-MV-b6h"/>

--- a/Jinkawa-iOS/EntryViewController.swift
+++ b/Jinkawa-iOS/EntryViewController.swift
@@ -16,6 +16,7 @@ class EntryViewController: FormViewController {
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         form
             +++ Section("申し込み情報")

--- a/Jinkawa-iOS/EventCreateViewController.swift
+++ b/Jinkawa-iOS/EventCreateViewController.swift
@@ -15,6 +15,7 @@ class EventCreateViewController: FormViewController {
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
 
         form

--- a/Jinkawa-iOS/EventDetailTableViewCell.swift
+++ b/Jinkawa-iOS/EventDetailTableViewCell.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class EventDetailTableViewCell: UITableViewCell {
 
-    
     @IBOutlet weak var title: UILabel!
     
     override func awakeFromNib() {

--- a/Jinkawa-iOS/EventDetailTableViewCell.xib
+++ b/Jinkawa-iOS/EventDetailTableViewCell.xib
@@ -18,24 +18,34 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="19b-n1-5VQ" customClass="EventDetailTableViewCell" customModule="Jinkawa_iOS" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q4i-aS-iM4">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ffr-ge-jcJ">
-                                <rect key="frame" x="139" y="10" width="173" height="24"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MfL-X1-BBE">
+                                <rect key="frame" x="140" y="8" width="172" height="27.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="MfL-X1-BBE" firstAttribute="leading" secondItem="q4i-aS-iM4" secondAttribute="leading" constant="140" id="3Su-Y7-4We"/>
+                            <constraint firstAttribute="trailing" secondItem="MfL-X1-BBE" secondAttribute="trailing" constant="8" id="6cA-LW-fRR"/>
+                            <constraint firstAttribute="bottom" secondItem="MfL-X1-BBE" secondAttribute="bottom" constant="8" id="RJX-jw-Qro"/>
+                            <constraint firstItem="MfL-X1-BBE" firstAttribute="top" secondItem="q4i-aS-iM4" secondAttribute="top" constant="8" id="ke9-Qk-GOU"/>
+                        </constraints>
                     </view>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="q4i-aS-iM4" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="AVu-y1-mG1"/>
+                    <constraint firstAttribute="bottom" secondItem="q4i-aS-iM4" secondAttribute="bottom" id="Tgd-qq-Toc"/>
+                    <constraint firstAttribute="trailing" secondItem="q4i-aS-iM4" secondAttribute="trailing" id="bbz-iI-Axh"/>
+                    <constraint firstItem="q4i-aS-iM4" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qDq-dc-3ma"/>
+                </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="title" destination="Ffr-ge-jcJ" id="QrF-KN-Uge"/>
+                <outlet property="title" destination="MfL-X1-BBE" id="0Eg-75-ocf"/>
             </connections>
         </tableViewCell>
     </objects>

--- a/Jinkawa-iOS/EventDetailViewController.swift
+++ b/Jinkawa-iOS/EventDetailViewController.swift
@@ -20,6 +20,7 @@ class EventDetailViewController: UIViewController, UITableViewDelegate, UITableV
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         //空のセルの境界線を消す
         detailTable.tableFooterView = UIView(frame: .zero)

--- a/Jinkawa-iOS/EventViewController.swift
+++ b/Jinkawa-iOS/EventViewController.swift
@@ -18,6 +18,7 @@ class EventViewController: UIViewController, UITableViewDelegate, UITableViewDat
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         //インジケーターの下に表示する文字列を設定する。
         refresh.attributedTitle = NSAttributedString(string: "読込中")

--- a/Jinkawa-iOS/InformationCreateViewController.swift
+++ b/Jinkawa-iOS/InformationCreateViewController.swift
@@ -15,6 +15,7 @@ class InformationCreateViewController: FormViewController {
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
 
         form

--- a/Jinkawa-iOS/InformationDetailViewController.swift
+++ b/Jinkawa-iOS/InformationDetailViewController.swift
@@ -19,6 +19,7 @@ class InformationDetailViewController: UIViewController, UITableViewDelegate, UI
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         //空のセルの境界線を消す
         detailTable.tableFooterView = UIView(frame: .zero)

--- a/Jinkawa-iOS/InformationDetailViewController.swift
+++ b/Jinkawa-iOS/InformationDetailViewController.swift
@@ -1,0 +1,70 @@
+//
+//  InformationDetailViewController.swift
+//  Jinkawa-iOS
+//
+//  Created by narihiro on 2017/10/22.
+//  Copyright © 2017年 Taro Sato. All rights reserved.
+//
+
+import UIKit
+
+class InformationDetailViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+   
+    var imformation: Information = Information()
+    var detailList:[String] = []
+    
+    @IBOutlet weak var detailTable: UITableView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = true
+        }
+        //空のセルの境界線を消す
+        detailTable.tableFooterView = UIView(frame: .zero)
+        
+        detailTable.delegate = self
+        detailTable.dataSource = self
+        
+        detailList.append(imformation.title)
+        detailList.append(imformation.date)
+        detailList.append(imformation.descriptionText)
+        
+        detailTable.register(UINib(nibName:"EventDetailTableViewCell", bundle:nil), forCellReuseIdentifier: "detailCell")
+        
+        //cellの高さを動的に変更する
+        detailTable.estimatedRowHeight = 40
+        detailTable.rowHeight = UITableViewAutomaticDimension
+        
+        // Do any additional setup after loading the view.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    // MARK: - UITableViewDataSource
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return detailList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "detailCell", for: indexPath) as! EventDetailTableViewCell
+        cell.title.text = detailList[indexPath.row]
+        cell.title.sizeToFit()
+        
+        return cell
+    }
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Jinkawa-iOS/InformationViewController.swift
+++ b/Jinkawa-iOS/InformationViewController.swift
@@ -20,6 +20,7 @@ class InformationViewController: UIViewController, UITableViewDelegate, UITableV
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         //インジケーターの下に表示する文字列を設定する。
         refresh.attributedTitle = NSAttributedString(string: "読込中")

--- a/Jinkawa-iOS/InformationViewController.swift
+++ b/Jinkawa-iOS/InformationViewController.swift
@@ -50,7 +50,7 @@ class InformationViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        //performSegue(withIdentifier: "toEventDetail", sender: EventManager.sharedInstance.getList()[indexPath.row])
+        performSegue(withIdentifier: "toInformationDetail", sender: InformationManager.sharedInstance.getList()[indexPath.row])
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -80,7 +80,10 @@ class InformationViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        
+        if segue.identifier == "toInformationDetail"{
+            let imformationDetailViewController = segue.destination as! InformationDetailViewController
+            imformationDetailViewController.imformation = sender as! Information
+        }
     }
     
     func refreshTable()

--- a/Jinkawa-iOS/PartisipantViewController.swift
+++ b/Jinkawa-iOS/PartisipantViewController.swift
@@ -21,6 +21,7 @@ class PartisipantViewController: UIViewController, UITableViewDelegate, UITableV
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
 
         participantTable.delegate = self

--- a/Jinkawa-iOS/SettingViewController.swift
+++ b/Jinkawa-iOS/SettingViewController.swift
@@ -20,6 +20,7 @@ class SettingViewController: UIViewController, UITableViewDelegate, UITableViewD
         super.viewDidLoad()
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
+            navigationController?.navigationBar.largeTitleTextAttributes = [NSForegroundColorAttributeName: UIColor.white]
         }
         
         settingTableView.delegate = self


### PR DESCRIPTION
お知らせアイテムをタップ時、詳細画面に遷移する.
おしらせ詳細画面のセルはイベント詳細画面のセルと同じカスタムセルを使用しています.
仕様に違いが出てきた場合は、新しくお知らせ用ののカスタムセルを作成します.

あと` largeTitle `の色を白に変更しました.