### PR TITLE
add 入力情報の保持

### DIFF
--- a/Jinkawa-iOS/Base.lproj/Main.storyboard
+++ b/Jinkawa-iOS/Base.lproj/Main.storyboard
@@ -351,6 +351,9 @@
             <objects>
                 <tableViewController id="IAh-ou-TAm" customClass="SettingViewController" customModule="Jinkawa_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" title="設定" id="1bi-62-Nlh"/>
+                    <connections>
+                        <segue destination="oxb-5A-vjQ" kind="presentation" identifier="toUserInformation" modalTransitionStyle="crossDissolve" id="cCZ-hV-Pso"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="COq-0Y-aao" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -365,11 +368,11 @@
                         <viewControllerLayoutGuide type="bottom" id="9RA-yi-EF6"/>
                     </layoutGuides>
                     <view key="view" tag="1" contentMode="scaleToFill" id="nnf-o1-fW7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="k8c-kx-TF5">
-                                <rect key="frame" x="67" y="177.5" width="240" height="312"/>
+                                <rect key="frame" x="67" y="153" width="240" height="312"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="RFi-Pt-zRn"/>

--- a/Jinkawa-iOS/Base.lproj/Main.storyboard
+++ b/Jinkawa-iOS/Base.lproj/Main.storyboard
@@ -362,7 +362,7 @@
         <!--User Information View Controller-->
         <scene sceneID="IvI-51-Nke">
             <objects>
-                <viewController storyboardIdentifier="UserInformationView" modalPresentationStyle="overCurrentContext" id="oxb-5A-vjQ" customClass="UserInformationViewController" customModule="Jinkawa_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UserInformationView" wantsFullScreenLayout="YES" modalPresentationStyle="overCurrentContext" id="oxb-5A-vjQ" customClass="UserInformationViewController" customModule="Jinkawa_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="a40-Uk-FhZ"/>
                         <viewControllerLayoutGuide type="bottom" id="9RA-yi-EF6"/>
@@ -371,25 +371,65 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="k8c-kx-TF5">
-                                <rect key="frame" x="67" y="153" width="240" height="312"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lk8-AF-CGl">
+                                <rect key="frame" x="46" y="130" width="283" height="378"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WTV-bG-gxd">
+                                        <rect key="frame" x="0.0" y="10" width="283" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="GGH-WO-XoS"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="k8c-kx-TF5">
+                                        <rect key="frame" x="10" y="90" width="263" height="238"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </tableView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u2q-5Y-4fe">
+                                        <rect key="frame" x="0.0" y="328" width="283" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="stv-d4-GRF"/>
+                                        </constraints>
+                                        <state key="normal" title="消去する">
+                                            <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                    </button>
+                                </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="240" id="RFi-Pt-zRn"/>
-                                    <constraint firstAttribute="height" constant="312" id="i8x-6A-xhk"/>
+                                    <constraint firstItem="u2q-5Y-4fe" firstAttribute="top" secondItem="k8c-kx-TF5" secondAttribute="bottom" id="3J1-Lw-gwy"/>
+                                    <constraint firstItem="u2q-5Y-4fe" firstAttribute="leading" secondItem="lk8-AF-CGl" secondAttribute="leading" id="C7y-Gu-mhH"/>
+                                    <constraint firstAttribute="trailing" secondItem="WTV-bG-gxd" secondAttribute="trailing" id="IhZ-Hc-uFD"/>
+                                    <constraint firstAttribute="trailing" secondItem="u2q-5Y-4fe" secondAttribute="trailing" id="Jjr-Nn-f9d"/>
+                                    <constraint firstItem="k8c-kx-TF5" firstAttribute="top" secondItem="WTV-bG-gxd" secondAttribute="bottom" constant="30" id="Q8D-L8-VlX"/>
+                                    <constraint firstItem="u2q-5Y-4fe" firstAttribute="top" secondItem="k8c-kx-TF5" secondAttribute="bottom" id="UhR-PS-dht"/>
+                                    <constraint firstItem="WTV-bG-gxd" firstAttribute="top" secondItem="lk8-AF-CGl" secondAttribute="top" constant="10" id="XEo-p9-YuZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="u2q-5Y-4fe" secondAttribute="bottom" id="YtF-dQ-CYJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="k8c-kx-TF5" secondAttribute="trailing" constant="10" id="ez5-sm-nGU"/>
+                                    <constraint firstItem="WTV-bG-gxd" firstAttribute="leading" secondItem="lk8-AF-CGl" secondAttribute="leading" id="qSt-75-gsz"/>
+                                    <constraint firstItem="k8c-kx-TF5" firstAttribute="leading" secondItem="lk8-AF-CGl" secondAttribute="leading" constant="10" id="uli-MN-u1L"/>
                                 </constraints>
-                            </tableView>
+                            </view>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="k8c-kx-TF5" firstAttribute="centerX" secondItem="nnf-o1-fW7" secondAttribute="centerX" id="Rrb-P8-wHz"/>
-                            <constraint firstItem="k8c-kx-TF5" firstAttribute="centerY" secondItem="nnf-o1-fW7" secondAttribute="centerY" id="jpe-pY-IHb"/>
+                            <constraint firstItem="lk8-AF-CGl" firstAttribute="top" secondItem="a40-Uk-FhZ" secondAttribute="bottom" constant="110" id="81m-rG-buo"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="lk8-AF-CGl" secondAttribute="trailing" constant="30" id="8mV-8j-Q2p"/>
+                            <constraint firstItem="lk8-AF-CGl" firstAttribute="leading" secondItem="nnf-o1-fW7" secondAttribute="leadingMargin" constant="30" id="Nai-Ac-YT2"/>
+                            <constraint firstItem="9RA-yi-EF6" firstAttribute="top" secondItem="lk8-AF-CGl" secondAttribute="bottom" constant="110" id="dbs-Tc-QQZ"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="eCM-1z-Pks"/>
+                    <connections>
+                        <outlet property="deleteButton" destination="u2q-5Y-4fe" id="OLs-ph-BLA"/>
+                        <outlet property="titleLabel" destination="WTV-bG-gxd" id="scC-zb-qVG"/>
+                        <outlet property="userInformationTable" destination="k8c-kx-TF5" id="IWa-4F-ehY"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="asw-30-nPO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3301.5999999999999" y="1665.5172413793105"/>
+            <point key="canvasLocation" x="3301.5999999999999" y="1665.0674662668666"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="adG-mE-Q36">

--- a/Jinkawa-iOS/EntryViewController.swift
+++ b/Jinkawa-iOS/EntryViewController.swift
@@ -162,13 +162,11 @@ class EntryViewController: FormViewController {
             return
         }
         
-        // Get the value of a single row
-        let nameRow = form.rowBy(tag: "NameRowTag") as! NameRow
-        let name = nameRow.value!
         
         // Get the value of all rows which have a Tag assigned
         let values = form.values()
         
+        let name:String = values["NameRowTag"] as! String
         let gender:String = values["GenderRowTag"] as! String
         let age:Int = values["AgeRowTag"] as! Int
         let tell:String = values["PhoneRowTag"] as! String
@@ -181,45 +179,42 @@ class EntryViewController: FormViewController {
                 "電話番号:" + tell + "\n" +
                 "住所:" + address
         
-        let alert = UIAlertController(title: "この内容で申し込みます",
-                                      message: message,
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "確定",
-                                      style: .default,
-                                      handler: {(UIAlertAction)-> Void in
-                                        let participant = Participant(name: name, gender: gender, age: age.description, tell: tell, address: address, event_id:self.event_id)
-                                        participant.save()
-                                        
-                                        let alertAfter = UIAlertController(title: "申し込みが確定されました",
-                                                                           message: nil,
-                                                                           preferredStyle: .alert)
-                                        let defaultAction: UIAlertAction = UIKit.UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler:{
-                                            // ボタンが押された時の処理を書く（クロージャ実装）
-                                            (action: UIAlertAction!) -> Void in
-                                            print("OK")
-                                            //前の画面に遷移する
-                                            self.navigationController?.popViewController(animated: true)
-                                        })
-                                        
-                                        alertAfter.addAction(defaultAction)
-                                        self.present(alertAfter, animated: true, completion: nil)
-        }))
-        alert.addAction(UIAlertAction(title: "キャンセル", style: UIAlertActionStyle.cancel, handler:{
-            // ボタンが押された時の処理を書く（クロージャ実装）
-            (action: UIAlertAction!) -> Void in
-            print("Cancel")
-            let alertCancel = UIAlertController(title: "キャンセルされました",
-                                                message: nil,
-                                                preferredStyle: .alert)
-            let defaultAction: UIAlertAction = UIKit.UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler:{
-                // ボタンが押された時の処理を書く（クロージャ実装）
-                (action: UIAlertAction!) -> Void in
-                print("OK")
-            })
+        
+        //アラート
+        let alert = UIAlertController(title: "この内容で申し込みます", message: message, preferredStyle: .alert)
+        
+        //確定ボタン
+        let confirmAction = UIAlertAction(title: "確定", style: .default){ (action: UIAlertAction) in
+            let participant = Participant(name: name, gender: gender, age: age.description, tell: tell, address: address, event_id:self.event_id)
+            participant.save()
+            print("participant data was saved")
             
-            alertCancel.addAction(defaultAction)
-            self.present(alertCancel, animated: true, completion: nil)
-        }))
+            //ユーザー情報の保存
+            UserDefaults.standard.set(values, forKey: "userInformation")
+            
+            let confirmAlert = UIAlertController(title: "申し込みが確定されました", message: nil, preferredStyle: .alert)
+            let okAction = UIKit.UIAlertAction(title: "OK", style: .default){ (action: UIAlertAction) in
+                print("OK")
+                //前の画面に遷移する
+                self.navigationController?.popViewController(animated: true)
+            }
+            confirmAlert.addAction(okAction)
+            self.present(confirmAlert, animated: true, completion: nil)
+        }
+        
+        //キャンセルボタン
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel){ (action: UIAlertAction) in
+            print("Cancel")
+            let cancelAlert = UIAlertController(title: "キャンセルされました", message: nil, preferredStyle: .alert)
+            let okAction: UIAlertAction = UIKit.UIAlertAction(title: "OK", style: .default){ (action: UIAlertAction) in
+                print("OK")
+            }
+            cancelAlert.addAction(okAction)
+            self.present(cancelAlert, animated: true, completion: nil)
+        }
+        
+        alert.addAction(confirmAction)
+        alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
     }
 }

--- a/Jinkawa-iOS/EntryViewController.swift
+++ b/Jinkawa-iOS/EntryViewController.swift
@@ -39,6 +39,9 @@ class EntryViewController: FormViewController {
                 $0.title = "氏名"
                 $0.add(rule: RuleRequired())
                 $0.validationOptions = .validatesOnBlur
+                if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                    $0.value = UserDefaults.standard.dictionary(forKey: "userInformation")?["NameRowTag"] as? String
+                }
                 }.onChange {
                     print("Name changed:", $0.value ?? "");
                 }.cellUpdate { cell, row in
@@ -65,11 +68,17 @@ class EntryViewController: FormViewController {
                 $0.title = "性別　　　　　"
                 $0.options = ["男", "女"]
                 $0.value = "男"    // initially selected
+                if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                    $0.value = UserDefaults.standard.dictionary(forKey: "userInformation")?["GenderRowTag"] as? String
+                }
             }
             <<< IntRow("AgeRowTag") {
                 $0.title = "年齢"
                 $0.add(rule: RuleRequired())
                 $0.validationOptions = .validatesOnChange
+                if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                    $0.value = UserDefaults.standard.dictionary(forKey: "userInformation")?["AgeRowTag"] as? Int
+                }
                 }
                 .onRowValidationChanged { cell, row in
                     let rowIndex = row.indexPath!.row
@@ -95,6 +104,9 @@ class EntryViewController: FormViewController {
                 $0.title = "電話番号"
                 $0.add(rule: RuleRequired())
                 $0.validationOptions = .validatesOnBlur
+                if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                    $0.value = UserDefaults.standard.dictionary(forKey: "userInformation")?["PhoneRowTag"] as? String
+                }
                 }
                 .cellUpdate{ cell, row in
                     if !row.isValid {
@@ -120,6 +132,9 @@ class EntryViewController: FormViewController {
                 $0.title = "住所"
                 $0.add(rule: RuleRequired())
                 $0.validationOptions = .validatesOnBlur
+                if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                    $0.value = UserDefaults.standard.dictionary(forKey: "userInformation")?["AddressRowTag"] as? String
+                }
                 }
                 .cellUpdate{ cell, row in
                     if !row.isValid {

--- a/Jinkawa-iOS/SettingViewController.swift
+++ b/Jinkawa-iOS/SettingViewController.swift
@@ -37,11 +37,17 @@ class SettingViewController: FormViewController {
             <<< LabelRow() {
                 $0.title = "入力情報の確認"
                 }.onCellSelection{ cell, row in
-                    self.performSegue(withIdentifier: "toUserInformation", sender: nil)
-//                    let nvc = self.storyboard!.instantiateViewController(withIdentifier: "UserInformationView")
-//                    nvc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-//                    self.present(nvc, animated: true, completion: nil)
-                    
+                    if UserDefaults.standard.object(forKey: "userInformation") != nil {
+                        self.performSegue(withIdentifier: "toUserInformation", sender: nil)
+//                        let nvc = self.storyboard!.instantiateViewController(withIdentifier: "UserInformationView")
+//                        nvc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+//                        self.present(nvc, animated: true, completion: nil)
+                    } else {
+                        let alert = UIAlertController(title: "入力情報の確認", message: "ユーザー情報がありません", preferredStyle: .alert)
+                        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+                        alert.addAction(okAction)
+                        self.present(alert, animated: true, completion: nil)
+                    }
             }
             +++ Section("アカウント"){ section in
                 if UserManager.sharedInstance.getState() == .common {
@@ -54,17 +60,17 @@ class SettingViewController: FormViewController {
             <<< ButtonRow() {
                 $0.title = "ログアウト"
                 }.onCellSelection { cell, row in
-                    let alertController = UIAlertController(title: "ログアウト",message: "ログアウトしますか", preferredStyle: UIAlertControllerStyle.alert)
-                    let okAction = UIAlertAction(title: "はい", style: UIAlertActionStyle.default){ (action: UIAlertAction) in
+                    let alertController = UIAlertController(title: "ログアウト", message: "ログアウトしますか", preferredStyle: .alert)
+                    let okAction = UIAlertAction(title: "はい", style: .default){ (action: UIAlertAction) in
                         UserManager.sharedInstance.setState(state: .common)
                         self.dismiss(animated: true, completion: nil)
                     }
-                    let cancelAction = UIAlertAction(title: "いいえ", style: UIAlertActionStyle.cancel, handler: nil)
+                    let cancelAction = UIAlertAction(title: "いいえ", style: .cancel, handler: nil)
                     
                     alertController.addAction(okAction)
                     alertController.addAction(cancelAction)
                     
-                    self.present(alertController,animated: true,completion: nil)
+                    self.present(alertController, animated: true, completion: nil)
             }
             +++ Section("お問い合わせ")
             <<< LabelRow() {

--- a/Jinkawa-iOS/SettingViewController.swift
+++ b/Jinkawa-iOS/SettingViewController.swift
@@ -37,9 +37,11 @@ class SettingViewController: FormViewController {
             <<< LabelRow() {
                 $0.title = "入力情報の確認"
                 }.onCellSelection{ cell, row in
-                    let nvc = self.storyboard!.instantiateViewController(withIdentifier: "UserInformationView")
-                    nvc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
-                    self.present(nvc, animated: true, completion: nil)
+                    self.performSegue(withIdentifier: "toUserInformation", sender: nil)
+//                    let nvc = self.storyboard!.instantiateViewController(withIdentifier: "UserInformationView")
+//                    nvc.modalTransitionStyle = UIModalTransitionStyle.crossDissolve
+//                    self.present(nvc, animated: true, completion: nil)
+                    
             }
             +++ Section("アカウント"){ section in
                 if UserManager.sharedInstance.getState() == .common {

--- a/Jinkawa-iOS/UserInformationViewController.swift
+++ b/Jinkawa-iOS/UserInformationViewController.swift
@@ -36,6 +36,8 @@ class UserInformationViewController: UIViewController, UITableViewDelegate, UITa
         titleLabel.textAlignment = .center
         titleLabel.font = UIFont.boldSystemFont(ofSize: 16.0)
         
+        deleteButton.addTarget(self, action: #selector(didTapDeleteButton(sender:)), for: .touchUpInside)
+        
         let userAge = userInformation!["AgeRowTag"] as! Int
         userInformation!["AgeRowTag"] = String(userAge)
         
@@ -72,6 +74,27 @@ class UserInformationViewController: UIViewController, UITableViewDelegate, UITa
         return cell
     }
     
+    func didTapDeleteButton(sender:UIButton){
+        let alertController = UIAlertController(title: "入力情報の消去", message: "入力情報を消去しますか", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "はい", style: .default){ (action: UIAlertAction) in
+            //入力情報の消去
+            UserDefaults.standard.removeObject(forKey: "userInformation")
+            
+            let alertController = UIAlertController(title: "入力情報の消去", message: "入力情報を消去しました", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "OK", style: .default){ (action: UIAlertAction) in
+                self.dismiss(animated: true, completion: nil)
+            }
+            
+            alertController.addAction(okAction)
+            self.present(alertController, animated: true, completion: nil)
+        }
+        let cancelAction = UIAlertAction(title: "いいえ", style: .cancel, handler: nil)
+        
+        alertController.addAction(okAction)
+        alertController.addAction(cancelAction)
+        
+        self.present(alertController, animated: true, completion: nil)
+    }
     /*
      // MARK: - Navigation
      

--- a/Jinkawa-iOS/UserInformationViewController.swift
+++ b/Jinkawa-iOS/UserInformationViewController.swift
@@ -8,15 +8,36 @@
 
 import UIKit
 
-class UserInformationViewController: UIViewController {
+class UserInformationViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var userInformationTable: UITableView!
+    @IBOutlet weak var deleteButton: UIButton!
+    
+    var userInformation = UserDefaults.standard.dictionary(forKey: "userInformation")
+    let userInformationCategory = ["名前","性別","年齢","電話番号","住所"]
+    let userInformationOrder = ["NameRowTag", "GenderRowTag", "AgeRowTag", "PhoneRowTag", "AddressRowTag"]
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
         
-        //        let visualEffectView = UIVisualEffectView(frame: view.frame)
-        //        visualEffectView.effect = UIBlurEffect(style: .regular)
-        //        view.insertSubview(visualEffectView, at: 0)
+        userInformationTable.delegate = self
+        userInformationTable.dataSource = self
+        
+        userInformationTable.register(UINib(nibName:"EventDetailTableViewCell", bundle:nil), forCellReuseIdentifier: "detailCell")
+        
+        userInformationTable.tableFooterView = UIView(frame: .zero)
+        
+        userInformationTable.estimatedRowHeight = 40
+        userInformationTable.rowHeight = UITableViewAutomaticDimension
+        
+        titleLabel.text = "入力情報の確認"
+        titleLabel.textAlignment = .center
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 16.0)
+        
+        let userAge = userInformation!["AgeRowTag"] as! Int
+        userInformation!["AgeRowTag"] = String(userAge)
         
         // Do any additional setup after loading the view.
     }
@@ -34,6 +55,21 @@ class UserInformationViewController: UIViewController {
                 dismiss(animated: true, completion: nil)
             }
         }
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 5
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "detailCell", for: indexPath) as! EventDetailTableViewCell
+        cell.category.text = userInformationCategory[indexPath.row]
+        //cell.category.textAlignment = .center
+        cell.category.font = UIFont.boldSystemFont(ofSize: 16.0)
+        print("\(String(describing: userInformation![userInformationOrder[indexPath.row]]))")
+        cell.content.text = userInformation![userInformationOrder[indexPath.row]] as? String
+        
+        return cell
     }
     
     /*


### PR DESCRIPTION
ユーザーがイベント参加登録をおこなった際、
` UserDefaults `を使用して端末にそのユーザー情報を保持するようにします.
それに伴い以下の機能を実装します.

- 保持情報の利用
イベント参加登録画面をおこなった場合、2回目以降は前回の情報が入力された状態で表示されます.
ユーザー情報を消去した場合、これらは表示されなくなります.

- 入力情報の確認
設定タブから現在保持されているユーザー情報を確認できるモーダルビューへ遷移することができます.
戻るときはビューの外側をタッチします.(これ廃止して閉じるボタンつけたほうがいいかも)
保持されているユーザー情報がない場合、アラートを表示します.

- 入力情報の消去
上記モーダルビュー内の「消去する」ボタンを押すことで現在のユーザー情報を消去することができます.


また統一性をとるためにモーダルビューへの画面遷移方法を` present `から` segue `に変更しました.

ついでにイベント参加登録時のアラート部分のコードがわかりずらかったので
軽く整理しました.(` UIAlertAction `の` hendler: `を外に出しました)
